### PR TITLE
Add benchmark for evaluating the parsing speed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # ignore jupyter notebooks in postprocessing in the language bar on github
 postprocessing/** linguist-vendored
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,19 @@
+# Benchmark for testing the parsing speed
+
+This benchmark will be used to evaluate different optimizations for
+[increasing the parsing speed](https://github.com/OpenEnergyPlatform/open-MaStR/issues/546). 
+
+It is based on the
+[Marktstammdatenregister (MaStR) dataset](https://www.marktstammdatenregister.de/MaStR/Datendownload). Since the data is
+public, using this dataset requires no anonymization or other additional measures.
+
+The benchmark consists of 3 datasets with variable sizes:
+
+| Dataset    | Compressed size | Uncompressed size |
+|------------|-----------------|-------------------|
+| small.zip  | 112.9 MB        | 2.17 GB           |
+| medium.zip | 452.2 MB        | 8.52 GB           |
+| large.zip  | 854.4 MB        | 16.1 GB           |
+
+The datasets were extracted from the MaStR by imposing certain conditions (e.g., each table can contribute with at most
+X files).

--- a/benchmark/large.zip
+++ b/benchmark/large.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c234fe5176134b02a7be944c2fabde0de02985389c0eff312489a6b86d177593
+size 854382156

--- a/benchmark/medium.zip
+++ b/benchmark/medium.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:246b402650e42775d1414b35701be90bb1326e80b916559d402d6d35948e72f7
+size 452247023

--- a/benchmark/small.zip
+++ b/benchmark/small.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ef5742de69ac235bc91d2162afc59aec40d81b8bc7c2de5d351e386daabc2f8
+size 112895320


### PR DESCRIPTION
- I documented the benchmark in the README.md file
- As the files are quite large (above the 100 MB threshold from Github), I enabled [Git-LFS (Git Large File Storage)](https://git-lfs.com). That means that the files are hosted on a different server and the repository contain only pointers to them. 